### PR TITLE
Teste inicial - NodeMCU ESP-32S

### DIFF
--- a/sensorbpm.ino
+++ b/sensorbpm.ino
@@ -1,0 +1,17 @@
+int PulseSensorPurplePin = 0;
+int Signal;
+int Threshold = 2400;
+
+void setup() {
+
+  Serial.begin(115200);
+
+}
+
+void loop() {
+  
+  Signal = analogRead(PulseSensorPurplePin);                     
+  Serial.println(Signal);                   
+delay(1500); 
+
+}


### PR DESCRIPTION
Feito teste inicial na placa ESP32S, no entanto, é necessário verificar a falha do que está acontecendo, pois no serial ainda permanece com uma falha para mostrar a pulsação.

Site de exemplo: https://openhomeautomation.net/bluetooth-heart-rate-sensor-arduino